### PR TITLE
feat: support one_task_per_node scheduler

### DIFF
--- a/build/spike.yaml
+++ b/build/spike.yaml
@@ -3,6 +3,7 @@ server_config:
   http_port: 8080
   request_timeout: 600 # in seconds
   max_retry: 3
+  scheduler_type: base
 
   # log config
   log_level: debug # debug/info/warn/error

--- a/cmd/server/config/config.go
+++ b/cmd/server/config/config.go
@@ -17,11 +17,12 @@ limitations under the License.
 package config
 
 import (
-	"github.com/AgentGuo/spike/pkg/constants"
-	"gopkg.in/yaml.v3"
 	"log"
 	"os"
 	"sync"
+
+	"github.com/AgentGuo/spike/pkg/constants"
+	"gopkg.in/yaml.v3"
 )
 
 var (
@@ -40,6 +41,9 @@ type ServerConfig struct {
 	HttpPort       int `yaml:"http_port"`
 	RequestTimeout int `yaml:"request_timeout"`
 	MaxRetry       int `yaml:"max_retry"`
+
+	// scheduler config
+	SchedulerType string `yaml:"scheduler_type"`
 
 	// log config
 	LogLevel  string `yaml:"log_level"`
@@ -81,6 +85,7 @@ func GetConfig() *SpikeConfig {
 				HttpPort:             8080,
 				RequestTimeout:       600,
 				MaxRetry:             3,
+				SchedulerType:        "base",
 				LogLevel:             "debug",
 				LogToFile:            false,
 				LogToStd:             true,

--- a/pkg/reqscheduler/reqscheduler.go
+++ b/pkg/reqscheduler/reqscheduler.go
@@ -40,6 +40,16 @@ type Response struct {
 	Err             error
 }
 
+// SchedulerType 调度器类型
+type SchedulerType string
+
+const (
+	// BaseSchedulerType 基础调度器
+	BaseSchedulerType SchedulerType = "base"
+	// OneTaskPerNodeSchedulerType 单任务调度器
+	OneTaskPerNodeSchedulerType SchedulerType = "one_task_per_node"
+)
+
 type ReqScheduler struct {
 	reqQueue       *ReqQueue
 	mysql          *storage.Mysql
@@ -52,8 +62,18 @@ type ReqScheduler struct {
 
 func NewReqScheduler() *ReqScheduler {
 	mysqlClient := storage.NewMysql()
+
+	// 根据配置选择调度器
+	var scheduler Scheduler
+	switch config.GetConfig().ServerConfig.SchedulerType {
+	case string(OneTaskPerNodeSchedulerType):
+		scheduler = &OneTaskPerNodeScheduler{}
+	default:
+		scheduler = &BaseScheduler{}
+	}
+
 	r := &ReqScheduler{
-		scheduler:      &BaseScheduler{},
+		scheduler:      scheduler,
 		mysql:          mysqlClient,
 		logger:         logger.GetLogger(),
 		reqQueue:       NewReqQueue(),


### PR DESCRIPTION
The `one_task_per_node` scheduler is added to integrate pipeline execution in pixels.